### PR TITLE
fix(vercel): remove any types and forbid require() import

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -12,7 +12,7 @@ export default function ProjectsPage() {
 
   // Map external projects.ts to the shape expected by GalleryCard
   const mapped = useMemo(() => {
-    return projects.filter((p:any) => p.display !== false && p.display === true).map((p) => ({
+    return projects.filter((p) => (p as { display?: boolean }).display === true).map((p) => ({
       title: p.title,
       description: p.description,
       tags: Array.isArray(p.techStack) ? p.techStack : [],

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -36,8 +36,8 @@ export default function Hero() {
   );
 }
 
+import StatsRow from "@/components/StatsRow";
 function StatsRowPlaceholder() {
-  const StatsRow = require("@/components/StatsRow").default;
   return <StatsRow />;
 }
 


### PR DESCRIPTION
- /projects page now maps and filters typed data from projects.ts (respects display)
- Replace loose any usage with safe narrowing
- Hero: replace dynamic require() with ES import for StatsRow
- Minor cleanup to satisfy Next.js/ESLint rules